### PR TITLE
Fix param retrieval

### DIFF
--- a/x/hickory/keeper/params.go
+++ b/x/hickory/keeper/params.go
@@ -7,7 +7,9 @@ import (
 
 // GetParams get all parameters as types.Params
 func (k Keeper) GetParams(ctx sdk.Context) types.Params {
-	return types.NewParams()
+	var params types.Params
+	k.paramstore.GetParamSet(ctx, &params)
+	return params
 }
 
 // SetParams set the params


### PR DESCRIPTION
## Summary
- ensure keeper.GetParams reads from the param store instead of returning defaults

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c7a36a1148321821e1d660450a85d